### PR TITLE
Remove prefix_datafile from pwnedpasswords_datastore_sorted_async output

### DIFF
--- a/src/hibp_downloader/commands/hibp_generate.py
+++ b/src/hibp_downloader/commands/hibp_generate.py
@@ -97,4 +97,4 @@ async def pwnedpasswords_datastore_sorted_async(prefix, hash_type):
         prepend_prefix=True,
     )
 
-    return {prefix: datafile_content, f"{prefix}_datafile": datafile_filepath}
+    return {prefix: datafile_content}


### PR DESCRIPTION
The output file produced by the generate command also includes the paths to the gz files (example: ntlm/07/f0/07f07.gz). With this patch, they are excluded.

Thanks