### PR TITLE
Speed up download and make more robust

### DIFF
--- a/src/hibp_downloader/commands/hibp_download.py
+++ b/src/hibp_downloader/commands/hibp_download.py
@@ -4,10 +4,27 @@ import os
 from datetime import datetime
 from multiprocessing import Manager, Process, Queue
 from pathlib import Path
-from typing import Any, List, Union
+from queue import Empty
+from typing import Any, Dict, List, Union
 
 import typer
+import httpx
 from typing_extensions import Annotated
+
+"""
+2026-04-05 Fixes and improvements from JimTheFrog and AI:
+Reused one event loop per worker process:
+- Worker now creates one event loop and one HTTP client once, then processes queue chunks on that same loop in line 229.
+- The loop/client lifecycle is closed in a finally path for cleanup in line 251.
+Added explicit failure tracking and non-zero exit:
+- Results processor now logs each failed prefix when download status is unknown in line 427.
+- Results processor sends failed-prefix count summary back to main in line 421.
+- Main process now exits with code 1 when failed prefixes are detected in line 178.
+- Added guard for missing summary payload and fail-fast behavior in line 171.
+Fixed interrupt (Ctrl-C) handling so there isn't a giant blast of tracebacks:
+- Worker child processes and queue process now catch KeyboardInterrupt and exit quietly in lines 242, 267, and 434.
+"""
+
 
 from hibp_downloader import (
     APPROX_GZIP_BYTES_PER_HASH,
@@ -26,7 +43,7 @@ from hibp_downloader import (
 from hibp_downloader.exceptions import HibpDownloaderException
 from hibp_downloader.lib.filedata import encoding_type_file_suffix, load_metadata, save_datafile, save_metadatafile
 from hibp_downloader.lib.generators import hex_sequence, iterable_chunker
-from hibp_downloader.lib.http import httpx_binary_response
+from hibp_downloader.lib.http import httpx_async_client, httpx_binary_response
 from hibp_downloader.lib.logger import logger_get
 from hibp_downloader.models import (
     HashType,
@@ -124,8 +141,10 @@ def main(
         ignore_etag = True
         local_cache_ttl = 0
 
-    result_queue = Manager().Queue()
-    results_queue_process = Process(target=results_queue_processor, args=(result_queue,))
+    manager = Manager()
+    result_queue = manager.Queue()
+    summary_queue = manager.Queue()
+    results_queue_process = Process(target=results_queue_processor, args=(result_queue, summary_queue))
     results_queue_process.daemon = True
     results_queue_process.start()
 
@@ -162,6 +181,21 @@ def main(
 
         result_queue.put(QUEUE_WORKER_EXIT_SENTINEL)
         results_queue_process.join()
+
+        try:
+            result_summary: Dict[str, int] = summary_queue.get(timeout=5)
+        except Empty:
+            logger.error("Download summary process did not return a failure-count summary")
+            raise typer.Exit(1)
+
+        failed_prefix_count = result_summary.get("failed_prefix_count", 0)
+
+        if failed_prefix_count > 0:
+            logger.error(
+                f"Download completed with {failed_prefix_count} failed prefixes; rerun download for the same range to recover."
+            )
+            raise typer.Exit(1)
+
         logger.info("Done")
 
     except KeyboardInterrupt:
@@ -208,17 +242,47 @@ def start_worker_processes(
 
 
 def queue_worker_process(work_queue: Queue, result_queue: Queue, worker_index: int, worker_args: WorkerArgs):
-    while True:
-        hash_prefixes = work_queue.get()
-        if hash_prefixes == QUEUE_WORKER_EXIT_SENTINEL:
-            break
-        worker_args.worker_index = worker_index
-        asyncio.run(pwnedpasswords_get_store_gather(result_queue, hash_prefixes, worker_args))
+    event_loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(event_loop)
+    http_client = httpx_async_client(
+        encoding=worker_args.encoding_type,
+        timeout=worker_args.http_timeout,
+        proxy=worker_args.http_proxy,
+        verify=worker_args.http_certificates,
+        debug=worker_args.http_debug,
+    )
+
+    try:
+        while True:
+            hash_prefixes = work_queue.get()
+            if hash_prefixes == QUEUE_WORKER_EXIT_SENTINEL:
+                break
+            worker_args.worker_index = worker_index
+            event_loop.run_until_complete(
+                pwnedpasswords_get_store_gather(result_queue, hash_prefixes, worker_args, http_client=http_client)
+            )
+    except KeyboardInterrupt:
+        return
+    finally:
+        try:
+            event_loop.run_until_complete(http_client.aclose())
+        except KeyboardInterrupt:
+            pass
+        finally:
+            event_loop.close()
 
 
-async def pwnedpasswords_get_store_gather(result_queue: Queue, hash_prefixes: tuple, worker_args: WorkerArgs) -> None:
+async def pwnedpasswords_get_store_gather(
+    result_queue: Queue,
+    hash_prefixes: tuple,
+    worker_args: WorkerArgs,
+    http_client: Union[httpx.AsyncClient, None] = None,
+) -> None:
     metadata_results = await asyncio.gather(
-        *[pwnedpasswords_get_and_store_async(hash_prefix, **worker_args.as_dict()) for hash_prefix in hash_prefixes],
+        *[
+            pwnedpasswords_get_and_store_async(hash_prefix, http_client=http_client, **worker_args.as_dict())
+            for hash_prefix in hash_prefixes
+        ],
     )
     result_queue.put(metadata_results)
 
@@ -237,6 +301,7 @@ async def pwnedpasswords_get_and_store_async(
     ignore_etag: bool,
     local_cache_ttl: int,
     worker_index: int,
+    http_client: Union[httpx.AsyncClient, None] = None,
 ) -> PrefixMetadata:
     logger_ = logger_get(name=LOGGER_NAME)
     start_timestamp = datetime.now().astimezone()
@@ -286,6 +351,7 @@ async def pwnedpasswords_get_and_store_async(
         http_proxy=http_proxy,
         http_certificates=http_certificates,
         http_debug=http_debug,
+        http_client=http_client,
     )
     metadata_latest.start_timestamp = start_timestamp
 
@@ -326,6 +392,7 @@ async def pwnedpasswords_get(
     http_proxy: str,
     http_certificates: str,
     http_debug: bool,
+    http_client: Union[httpx.AsyncClient, None] = None,
 ):
     url = f"{PWNEDPASSWORDS_API_URL}/range/{prefix}"
     if hash_type == HashType.ntlm:
@@ -341,19 +408,22 @@ async def pwnedpasswords_get(
             max_retries=http_max_retires,
             proxy=http_proxy,
             verify=http_certificates,
+            client=http_client,
         )
     except HibpDownloaderException:
         return None, PrefixMetadata(prefix=prefix, data_source=PrefixMetadataDataSource.unknown_source_status)
+
+    binary = getattr(response, "binary", b"")
 
     metadata = PrefixMetadata(
         prefix=prefix,
         hash_type=hash_type,
         etag=response.headers.get("etag"),
-        bytes=len(response.binary),
+        bytes=len(binary),
         server_timestamp=response.headers.get("date"),
         last_modified=response.headers.get("last-modified"),
         content_encoding=response.headers.get("content-encoding"),
-        content_checksum=hashlib.sha256(response.binary).hexdigest() if response.binary else None,
+        content_checksum=hashlib.sha256(binary).hexdigest() if binary else None,
     )
 
     if response.status_code == 304:  # HTTP 304 Not Modified status
@@ -366,36 +436,43 @@ async def pwnedpasswords_get(
     else:
         metadata.data_source = PrefixMetadataDataSource.unknown_source_status
 
-    return response.binary, metadata
+    return binary, metadata
 
 
-def results_queue_processor(q: Queue):
+def results_queue_processor(q: Queue, summary_queue: Queue):
     running_stats = QueueRunningStats()
 
-    while True:
-        metadata_items = q.get()
-        if metadata_items == QUEUE_WORKER_EXIT_SENTINEL:
-            running_stats.end_trigger()
-            logger.info(f"Finished in {round(running_stats.run_time / 60, 1)}min")
-            break
+    try:
+        while True:
+            metadata_items = q.get()
+            if metadata_items == QUEUE_WORKER_EXIT_SENTINEL:
+                running_stats.end_trigger()
+                logger.info(f"Finished in {round(running_stats.run_time / 60, 1)}min")
+                summary_queue.put({"failed_prefix_count": running_stats.unknown_source_status_count_sum})
+                break
 
-        if metadata_items:
-            running_stats.add_item_stats(item=QueueItemStatsCompute(metadata_items).stats)
+            if metadata_items:
+                for metadata_item in metadata_items:
+                    if metadata_item.data_source == PrefixMetadataDataSource.unknown_source_status:
+                        logger.error(f"Failed to download prefix {metadata_item.prefix!r}; local data file was not updated")
+                running_stats.add_item_stats(item=QueueItemStatsCompute(metadata_items).stats)
 
-        if running_stats.queue_item_count % LOGGING_INFO_EVENT_MODULUS == 0:
-            logger.info(
-                f"prefix={running_stats.prefix_latest} "
-                f"source=[lc:{running_stats.local_source_ttl_cache_count_sum} "
-                f"et:{running_stats.local_source_etag_match_count_sum} "
-                f"rc:{running_stats.remote_source_remote_cache_count_sum} "
-                f"ro:{running_stats.remote_source_origin_source_count_sum} "
-                f"xx:{running_stats.unknown_source_status_count_sum}] "
-                f"processed=[{to_mbytes(running_stats.bytes_processed_sum, 1)}MB "
-                f"~{int(running_stats.bytes_processed_rate_total / APPROX_GZIP_BYTES_PER_HASH)}H/s] "
-                f"api=[{int(running_stats.request_rate_total)}req/s "
-                f"{to_mbytes(running_stats.bytes_received_sum, 1)}MB] "
-                f"runtime={round(running_stats.run_time / 60, 1)}min"
-            )
+            if running_stats.queue_item_count % LOGGING_INFO_EVENT_MODULUS == 0:
+                logger.info(
+                    f"prefix={running_stats.prefix_latest} "
+                    f"source=[lc:{running_stats.local_source_ttl_cache_count_sum} "
+                    f"et:{running_stats.local_source_etag_match_count_sum} "
+                    f"rc:{running_stats.remote_source_remote_cache_count_sum} "
+                    f"ro:{running_stats.remote_source_origin_source_count_sum} "
+                    f"xx:{running_stats.unknown_source_status_count_sum}] "
+                    f"processed=[{to_mbytes(running_stats.bytes_processed_sum, 1)}MB "
+                    f"~{int(running_stats.bytes_processed_rate_total / APPROX_GZIP_BYTES_PER_HASH)}H/s] "
+                    f"api=[{int(running_stats.request_rate_total)}req/s "
+                    f"{to_mbytes(running_stats.bytes_received_sum, 1)}MB] "
+                    f"runtime={round(running_stats.run_time / 60, 1)}min"
+                )
+    except KeyboardInterrupt:
+        return
 
 
 def to_mbytes(value, rounding=None):

--- a/src/hibp_downloader/lib/app.py
+++ b/src/hibp_downloader/lib/app.py
@@ -9,6 +9,13 @@ from .. import HELP_EPILOG_FOOTER, LOGGER_NAME, __title__, __version__, app_cont
 from ..exceptions import HibpDownloaderException
 from ..lib.logger import logger_get
 
+"""
+2026-04-05 Bug fix JimTheFrog and the AI:
+Data_path was not optional at parse time, preventing subcommand help from displaying:
+- Added default empty string at app.py line 50.
+- Non-help execution still enforces --data-path with error at app.py:73.
+"""
+
 logger = logger_get(name=LOGGER_NAME)
 app = typer.Typer(
     add_completion=app_context.add_completion,
@@ -41,7 +48,7 @@ def main(
             envvar="HIBPDL_DATA_PATH",
             show_envvar=False,
         ),
-    ],
+    ] = "",
     metadata_path: Annotated[
         str,
         typer.Option(
@@ -72,6 +79,9 @@ def main(
     # return early if --help is all we need
     if "--help" in sys.argv:
         return
+
+    if not data_path:
+        raise typer.BadParameter("Missing option '--data-path'", param_hint="--data-path")
 
     # debug is captured at __init__; referenced here for happy linters
     if debug:

--- a/src/hibp_downloader/lib/http.py
+++ b/src/hibp_downloader/lib/http.py
@@ -1,10 +1,22 @@
 import random
+from typing import Any, Dict, Optional
 
 import httpx
 
 from hibp_downloader import LOGGER_NAME, __title__, __version__
 from hibp_downloader.exceptions import HibpDownloaderException
 from hibp_downloader.lib.logger import logger_get
+
+"""
+2026-04-05 Fixes and improvements from JimTheFrog and AI: Reused HTTP client instead of creating one per request
+- Added a reusable client factory and shared request path in http.py:66, http.py:86, and http.py:129.
+- Updated the main response function to accept an optional injected client in http.py:28.
+- Retry handling is now iterative in one client context rather than recursive client recreation.
+- Reused one event loop per worker process
+- Worker now creates one event loop and one HTTP client once, then processes queue chunks on that same loop in hibp_download.py:229.
+- The loop/client lifecycle is closed in a finally path for cleanup in hibp_download.py:251.
+"""
+
 
 logger = logger_get(LOGGER_NAME)
 
@@ -33,9 +45,63 @@ async def httpx_binary_response(
     max_retries=3,
     proxy="",
     verify="",
-    __attempt=0,
     debug=False,
+    client: Optional[httpx.AsyncClient] = None,
 ):
+    httpx_client = httpx_client_options(
+        etag=etag,
+        encoding=encoding,
+        timeout=timeout,
+        proxy=proxy,
+        verify=verify,
+        debug=debug,
+    )
+
+    if client:
+        return await _httpx_binary_response_with_client(
+            client=client,
+            url=url,
+            method=method,
+            max_retries=max_retries,
+        )
+
+    async with httpx.AsyncClient(**httpx_client) as http_client:
+        return await _httpx_binary_response_with_client(
+            client=http_client,
+            url=url,
+            method=method,
+            max_retries=max_retries,
+        )
+
+
+def httpx_async_client(
+    etag=None,
+    encoding="gzip",
+    timeout=10,
+    proxy="",
+    verify="",
+    debug=False,
+) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        **httpx_client_options(
+            etag=etag,
+            encoding=encoding,
+            timeout=timeout,
+            proxy=proxy,
+            verify=verify,
+            debug=debug,
+        )
+    )
+
+
+def httpx_client_options(
+    etag=None,
+    encoding="gzip",
+    timeout=10,
+    proxy="",
+    verify="",
+    debug=False,
+) -> Dict[str, Any]:
     event_hooks = {}
     if debug:
         event_hooks["request"] = [httpx_debug_request]
@@ -51,7 +117,7 @@ async def httpx_binary_response(
     if etag:
         headers["If-None-Match"] = etag
 
-    httpx_client = {
+    client_options: Dict[str, Any] = {
         "headers": headers,
         "http2": True,
         "timeout": timeout,
@@ -60,41 +126,45 @@ async def httpx_binary_response(
     }
 
     if not proxy == "":
-        httpx_client["proxy"] = proxy
+        client_options["proxy"] = proxy
 
     if not verify == "":
-        httpx_client["verify"] = verify
+        client_options["verify"] = verify
 
     if event_hooks:
-        httpx_client["event_hooks"] = event_hooks
+        client_options["event_hooks"] = event_hooks
+
+    return client_options
+
+
+async def _httpx_binary_response_with_client(
+    client: httpx.AsyncClient,
+    url,
+    method="GET",
+    max_retries=3,
+):
+    original_url = url
+    attempt = 0
 
     if __TESTING_RANDOM_ERROR_INJECT_RATE and __TESTING_RANDOM_ERROR_INJECT_RATE > random.random():
         url = url.replace("http", "BR0KEN")
         logger.warning(f"Testing, creating broken URL {url}")
 
-    async with httpx.AsyncClient(**httpx_client) as client:
-        __attempt += 1
-        logger.debug(f"Request attempt {__attempt} of {max_retries} for {url!r}")
+    while attempt < max_retries:
+        attempt += 1
+        logger.debug(f"Request attempt {attempt} of {max_retries} for {url!r}")
         request = client.build_request(method=method, url=url)
+        response = None
         try:
             response = await client.send(request=request, stream=True)
-        except (httpx.ConnectError, httpx.RemoteProtocolError, httpx.HTTPError):
-            logger.warning(f"Request [{__attempt} of {max_retries}] failed for {request.method!r} {url!r}")
-            if __attempt < max_retries:
-                return await httpx_binary_response(
-                    url.replace("BR0KEN", "http"),
-                    etag,
-                    method,
-                    encoding,
-                    timeout,
-                    max_retries,
-                    proxy,
-                    verify,
-                    __attempt,
-                    debug,
-                )
-            raise HibpDownloaderException(f"Request failed after {__attempt} retries: {url!r}")
+            setattr(response, "binary", b"".join([part async for part in response.aiter_raw()]))
+            await response.aclose()
+            return response
+        except httpx.HTTPError:
+            if response is not None:
+                await response.aclose()
+            logger.warning(f"Request [{attempt} of {max_retries}] failed for {request.method!r} {url!r}")
+            url = original_url
+            continue
 
-        response.binary = b"".join([part async for part in response.aiter_raw()])
-
-    return response
+    raise HibpDownloaderException(f"Request failed after {attempt} retries: {original_url!r}")


### PR DESCRIPTION
Reused HTTP client instead of creating one per request:
- Added a reusable client factory and shared request path in http.py:66, http.py:86, and http.py:129.
- Updated the main response function to accept an optional injected client in http.py:28.
- Retry handling is now iterative in one client context rather than recursive client recreation.
- Reused one event loop per worker process
- Worker now creates one event loop and one HTTP client once, then processes queue chunks on that same loop in hibp_download.py:229.
- The loop/client lifecycle is closed in a final path for cleanup in hibp_download.py:251.

Added explicit failure tracking and non-zero exit:
- Results processor now logs each failed prefix when download status is unknown in line 427.
- Results processor sends failed-prefix count summary back to main in line 421.
- Main process now exits with code 1 when failed prefixes are detected in line 178.
- Added guard for missing summary payload and fail-fast behavior in line 171.

Fixed interrupt (Ctrl-C) handling so there isn't a giant blast of tracebacks: *(Should have been a separate branch?)*
- Worker child processes and queue process now catch KeyboardInterrupt and exit quietly in lines 242, 267, and 434.

Fixed command-line "download --help" and "generate --help". *(Should have been a separate branch?)*

Vibe coded, but tested. Downloaded the HIBP data in about an hour instead of 31 hours. 